### PR TITLE
feat: Implement OTA handling

### DIFF
--- a/.github/actions/import-system-symbols-from-ipsw/action.yml
+++ b/.github/actions/import-system-symbols-from-ipsw/action.yml
@@ -6,6 +6,10 @@ inputs:
     required: true
   os_version:
     default: 'latest'
+  fetch_ipsw:
+    default: true
+  fetch_ota:
+    default: false
 
 runs:
   using: composite
@@ -13,6 +17,11 @@ runs:
     - uses: ./.github/actions/setup-import-system-symbols
       with:
         gcp_service_key: ${{ inputs.gcp_service_key }}
-    - name: Import symbols
+    - name: Import symbols from IPSW
       shell: bash
-      run: python3 import_system_symbols_from_ipsw.py --os_name ${{ inputs.os_name }} --os_version ${{ inputs.os_version }}
+      if: ${{ inputs.fetch_ipsw }}
+      run: python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
+    - name: Import symbols from OTA
+      shell: bash
+      if: ${{ inputs.fetch_ota }}
+      run: python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -26,7 +26,10 @@ runs:
         gcloud auth activate-service-account --key-file="$key_path"
     - name: "Install dependencies"
       shell: bash
-      run: brew install p7zip keith/formulae/dyld-shared-cache-extractor
+      run: brew install p7zip lzip keith/formulae/dyld-shared-cache-extractor
+    - name: "Compile ios-utils"
+      shell: bash
+      run: cd ios-utils && make
     - name: "Install symsorter"
       shell: bash
       run: |

--- a/.github/workflows/import-system-symbols-from-ipsw-manually.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-manually.yml
@@ -17,6 +17,16 @@ on:
         required: true
         type: string
         default: 'latest'
+      fetch_ipsw:
+        description: 'Fetch IPSW?'
+        required: false
+        type: boolean
+        default: true
+      fetch_ota:
+        description: 'Fetch OTA?'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   import-system-symbols-from-ipsw:
@@ -29,3 +39,5 @@ jobs:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
         os_name: ${{ github.event.inputs.os_name }}
         os_version: ${{ github.event.inputs.os_version }}
+        fetch_ipsw: ${{ github.event.inputs.fetch_ipsw == true }}
+        fetch_ota: ${{ github.event.inputs.fetch_ota == true }}

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -19,6 +19,7 @@ jobs:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
         os_name: tvos
         os_version: latest
+        fetch_ota: true
   import-ios-system-symbols-from-ipsw:
     runs-on: 'macos-12'
     steps:
@@ -29,6 +30,7 @@ jobs:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
         os_name: ios
         os_version: latest
+        fetch_ota: true
   import-macos-system-symbols-from-ipsw:
     runs-on: 'macos-12'
     steps:
@@ -39,6 +41,7 @@ jobs:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
         os_name: macos
         os_version: latest
+        fetch_ota: false
   import-watchos-system-symbols-from-ipsw:
     runs-on: 'macos-12'
     steps:
@@ -49,3 +52,4 @@ jobs:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
         os_name: watchos
         os_version: latest
+        fetch_ota: true

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ python3 -m pip install --user -r requirements.txt
 ### Upload simulators
 You need to specify which os you want to extract the symbols for and it will target the latest version.
 ```python
-python3 import_system_symbols_from_ipsw.py --os_name tvos
+python3 import_system_symbols_from_ipsw.py --os-name tvos
 ```
 You can also specify a specific version of the OS.
 ```python
-python3 import_system_symbols_from_ipsw.py --os_name tvos --os_version 15.3
+python3 import_system_symbols_from_ipsw.py --os-name tvos --os-version 15.3
 ```
 The script to extract from simulators doesn't take any argument.
 ```python

--- a/import_system_symbols_from_ipsw.py
+++ b/import_system_symbols_from_ipsw.py
@@ -5,6 +5,7 @@ import plistlib
 import subprocess
 import sys
 import tempfile
+from datetime import datetime
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List
@@ -12,6 +13,9 @@ from urllib.parse import ParseResult, urlparse
 
 import requests
 import sentry_sdk
+
+
+IOS_UTILS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ios-utils")
 
 
 @dataclass
@@ -55,6 +59,19 @@ class IPSW:
         return f"{self.os_version}_{self.build_number}_{self.architecture}"
 
 
+@dataclass
+class OTA:
+    build_number: str
+    device_identifier: str
+    os_name: str
+    os_version: str
+    url: ParseResult
+
+    @property
+    def bundle_id(self) -> str:
+        return f"{self.device_identifier}_{self.os_version}_{self.build_number}_ota"
+
+
 def main():
     logging.basicConfig(level=logging.INFO, format="[sentry] %(message)s")
     parser = argparse.ArgumentParser(
@@ -68,18 +85,61 @@ def main():
     )
     args = parser.parse_args()
 
-    with sentry_sdk.start_transaction(op="task", name="checking OTAs") as transaction:
-        get_otas(args.os_name)
-        sys.exit(1)
-
     if args.os_name is None:
         sys.exit("You need to specify an OS name to check for.")
 
+    main_download_otas(args.os_name, args.os_version)
+    main_download_ipsws(args.os_name, args.os_version)
+
+
+def main_download_otas(os_name: str, os_version: str):
+    with sentry_sdk.start_transaction(
+        op="task", name="import symbols from OTA archive"
+    ) as transaction:
+        with sentry_sdk.start_transaction(op="task", name="checking OTAs") as transaction:
+            with transaction.start_child(op="task", description="Check for new versions") as span:
+                otas = get_missing_ota_only_releases(os_name, os_version)
+                if len(otas) == 0:
+                    return
+                span.set_data("new_archives", otas)
+
+        with tempfile.TemporaryDirectory(prefix="_sentry_symcache_output_") as symcache_output:
+            with tempfile.TemporaryDirectory(prefix="_sentry_ota_archives_") as ota_dir:
+                for ota in otas:
+                    with transaction.start_child(
+                        op="task", description="Process OTA archive"
+                    ) as ota_span:
+                        for k, v in asdict(ota).items():
+                            ota_span.set_data(k, v)
+
+                        with ota_span.start_child(
+                            op="task", description="Download new version"
+                        ) as span:
+                            local_path = os.path.join(ota_dir, os.path.basename(ota.url.path))
+                            url = ota.url.geturl()
+                            span.set_data("url", url)
+                            download_archive(url, local_path)
+
+                        with ota_span.start_child(
+                            op="task", description="Extract symbols from archive"
+                        ) as span:
+                            extract_symbols_from_one_ota_archive(
+                                local_path,
+                                symcache_output,
+                                os_name,
+                                ota.bundle_id,
+                            )
+
+            with transaction.start_child(op="task", description="Upload symbols to GCS bucket"):
+                upload_to_gcs(symcache_output)
+
+
+def main_download_ipsws(os_name: str, os_version: str):
     with sentry_sdk.start_transaction(
         op="task", name="import symbols from IPSW archive"
     ) as transaction:
         with transaction.start_child(op="task", description="Check for new versions") as span:
-            ipsws = get_missing_ipsws(args.os_name, args.os_version)
+            ipsws = get_missing_ipsws(os_name, os_version)
             if len(ipsws) == 0:
                 return
             span.set_data("new_archives", ipsws)
@@ -99,14 +159,14 @@ def main():
                             local_path = os.path.join(ipsw_dir, os.path.basename(ipsw.url.path))
                             url = ipsw.url.geturl()
                             span.set_data("url", url)
-                            download_ipsw_archive(url, local_path)
+                            download_archive(url, local_path)
                         with ipsw_span.start_child(
                             op="task", description="Extract symbols from archive"
                         ) as span:
                             with tempfile.TemporaryDirectory(
                                 prefix="_sentry_ipsw_extract_dir_"
                             ) as extract_dir:
-                                extract_symbols_from_one_archive(
+                                extract_symbols_from_one_ipsw_archive(
                                     local_path,
                                     extract_dir,
                                     symcache_output,
@@ -117,7 +177,7 @@ def main():
                 upload_to_gcs(symcache_output)
 
 
-def download_ipsw_archive(url: str, filepath: str) -> None:
+def download_archive(url: str, filepath: str) -> None:
     logging.info(f"Downloading {url}")
     r = requests.get(url, stream=True)
     with open(filepath, "wb") as f:
@@ -125,7 +185,7 @@ def download_ipsw_archive(url: str, filepath: str) -> None:
             f.write(chunk)
 
 
-def extract_symbols_from_one_archive(
+def extract_symbols_from_one_ipsw_archive(
     ipsw_archive_path: str,
     extract_dir: str,
     symcache_output_path: str,
@@ -134,11 +194,11 @@ def extract_symbols_from_one_archive(
 ) -> None:
     span = sentry_sdk.Hub.current.scope.span
     with span.start_child(op="task", description="Extract IPSW archive"):
-        extract_ipsw_archive(ipsw_archive_path, extract_dir)
+        extract_zip_archive(ipsw_archive_path, extract_dir)
     plist_path = os.path.join(extract_dir, "Restore.plist")
     (restore_images, os_version, build_number) = read_restore_plist(plist_path)
 
-    # Use the first one only since the rest is the recovery OS
+    # Use the first one only since the rest is the otaecovery OS
     system_restore_image_filename = list(restore_images.keys())[0]
     restore_image_path = os.path.join(extract_dir, system_restore_image_filename)
 
@@ -178,34 +238,11 @@ def extract_symbols_from_one_archive(
             # To extract these, Xcode 13.0+ needs to be the selected Xcode version.
             if not filename.startswith("dyld_shared_cache") or os.path.splitext(filename)[1] != "":
                 continue
-            with tempfile.TemporaryDirectory(prefix="_sentry_dylib_cache_output") as output_path:
-                with span.start_child(
-                    op="task", description="Process shared cache file"
-                ) as shared_cache_span:
-                    shared_cache_span.set_data("shared_cache_file", filename)
-                    cache_path = os.path.join(shared_cache_dir, filename)
-                    logging.info(f"Extracting {cache_path} to {output_path}")
-                    with shared_cache_span.start_child(
-                        op="task", description="Run dyld-shared-cache-extractor"
-                    ):
-                        subprocess.check_call(
-                            ["dyld-shared-cache-extractor", cache_path, output_path]
-                        )
-                    with shared_cache_span.start_child(
-                        op="task", description="Run symsorter for shared cache directory"
-                    ):
-                        symsorter(symcache_output_path, prefix, bundle_id, output_path)
+            process_shared_cache_file(
+                filename, shared_cache_dir, prefix, bundle_id, symcache_output_path
+            )
 
-        other_dylib_paths = [
-            os.path.join(volume_path, "usr", "lib"),
-            os.path.join(volume_path, "System", "Library", "AccessibilityBundles"),
-        ]
-        for dylib_path in other_dylib_paths:
-            with span.start_child(
-                op="task", description="Run symsorter for other dylib paths"
-            ) as other_path_span:
-                other_path_span.set_data("dylib_path", dylib_path)
-                symsorter(symcache_output_path, prefix, bundle_id, dylib_path)
+        symsort_utilities(volume_path, prefix, bundle_id, symcache_output_path)
     finally:
         logging.info(f"Unmounting {restore_image_path}")
         with span.start_child(op="task", description="Unmount archive"):
@@ -214,6 +251,110 @@ def extract_symbols_from_one_archive(
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
+
+
+def extract_symbols_from_one_ota_archive(
+    ota_archive_path: str,
+    symcache_output_path: str,
+    prefix: str,
+    bundle_id: str,
+) -> None:
+    span = sentry_sdk.Hub.current.scope.span
+    with tempfile.TemporaryDirectory(prefix="_sentry_ota_extract_dir_") as level1_extract_dir:
+        uncompressed_payload = os.path.join(level1_extract_dir, "uncompressed_payload")
+
+        with span.start_child(op="task", description="Extract OTA archive"):
+            extract_zip_archive(ota_archive_path, level1_extract_dir)
+        with span.start_child(op="task", description="Decompress payloadv2"):
+            decompress_payloadv2(
+                os.path.join(level1_extract_dir, "AssetData", "payloadv2", "payload"),
+                uncompressed_payload,
+            )
+
+        with tempfile.TemporaryDirectory(
+            prefix="_sentry_final_ota_extract_dir_"
+        ) as level2_extract_dir:
+            with span.start_child(op="task", description="Unpack OTA from payload"):
+                unpack_ota(uncompressed_payload, level2_extract_dir)
+
+            shared_cache_dir = os.path.join(
+                level2_extract_dir,
+                "System",
+                "Library",
+                "Caches",
+                "com.apple.dyld",
+            )
+
+            for filename in os.listdir(shared_cache_dir):
+                if (
+                    not filename.startswith("dyld_shared_cache")
+                    or os.path.splitext(filename)[1] != ""
+                ):
+                    continue
+                process_shared_cache_file(
+                    filename, shared_cache_dir, prefix, bundle_id, symcache_output_path
+                )
+
+            symsort_utilities(level2_extract_dir, prefix, bundle_id, symcache_output_path)
+
+
+def decompress_payloadv2(payload_path: str, output_path: str) -> None:
+    logging.info(f"Uncompressing {payload_path}")
+    with open(payload_path, "rb") as payload:
+        with open(output_path, "wb") as output:
+            subprocess.check_call(
+                [os.path.join(IOS_UTILS_DIR, "pbzx"), payload_path],
+                stdin=payload,
+                stdout=output,
+                stderr=subprocess.DEVNULL,
+            )
+
+
+def unpack_ota(payload_path: str, output_path: str) -> None:
+    logging.info(f"Unpacking OTA from {payload_path}")
+    subprocess.check_call(
+        [os.path.join(IOS_UTILS_DIR, "ota"), "-e", payload_path],
+        cwd=output_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def process_shared_cache_file(
+    filename: str, shared_cache_dir: str, prefix: str, bundle_id: str, symcache_output_path: str
+) -> None:
+    span = sentry_sdk.Hub.current.scope.span
+    with tempfile.TemporaryDirectory(prefix="_sentry_dylib_cache_output") as output_path:
+        with span.start_child(
+            op="task", description="Process shared cache file"
+        ) as shared_cache_span:
+            shared_cache_span.set_data("shared_cache_file", filename)
+            cache_path = os.path.join(shared_cache_dir, filename)
+            logging.info(f"Extracting {cache_path} to {output_path}")
+            with shared_cache_span.start_child(
+                op="task", description="Run dyld-shared-cache-extractor"
+            ):
+                subprocess.check_call(["dyld-shared-cache-extractor", cache_path, output_path])
+            with shared_cache_span.start_child(
+                op="task", description="Run symsorter for shared cache directory"
+            ):
+                symsorter(symcache_output_path, prefix, bundle_id, output_path)
+
+
+def symsort_utilities(
+    volume_path: str, prefix: str, bundle_id: str, symcache_output_path: str
+) -> None:
+    span = sentry_sdk.Hub.current.scope.span
+    other_dylib_paths = [
+        os.path.join(volume_path, "usr", "lib"),
+        os.path.join(volume_path, "System", "Library", "AccessibilityBundles"),
+    ]
+    for dylib_path in other_dylib_paths:
+        with span.start_child(
+            op="task", description="Run symsorter for other dylib paths"
+        ) as other_path_span:
+            other_path_span.set_data("dylib_path", dylib_path)
+            symsorter(symcache_output_path, prefix, bundle_id, dylib_path)
 
 
 def symsorter(output_path: str, prefix: str, bundle_id: str, input_path: str) -> None:
@@ -233,7 +374,7 @@ def symsorter(output_path: str, prefix: str, bundle_id: str, input_path: str) ->
     )
 
 
-def extract_ipsw_archive(archive_path: str, extract_dir: str) -> None:
+def extract_zip_archive(archive_path: str, extract_dir: str) -> None:
     logging.info(f"Extracting {archive_path} to {extract_dir}")
     subprocess.check_call(
         ["unzip", archive_path, "-d", extract_dir],
@@ -264,7 +405,11 @@ def upload_to_gcs(symcache_dir: str):
     )
 
 
-def get_otas(os_name: str):
+def parse_date(date: str) -> datetime:
+    return datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
+
+
+def get_missing_ota_only_releases(os_name: str, version: str) -> List[OTA]:
     versions = {}
 
     span = sentry_sdk.Hub.current.scope.span
@@ -273,14 +418,26 @@ def get_otas(os_name: str):
             res = requests.get(f"https://api.ipsw.me/v4/device/{device.identifier}?type=ota")
             res.raise_for_status()
 
-            for firmware in res.json()["firmwares"]:
-                # we don't care about beta releases
-                if firmware["releasetype"] == "Beta":
-                    continue
-                normal_version = regular_version_from_ota_version(firmware["version"])
-                versions[normal_version, firmware["buildid"]] = firmware
+            qualifying_firmwares = sorted(
+                [x for x in res.json()["firmwares"] if x["releasetype"] != "Beta"],
+                key=lambda x: parse_date(x["releasedate"]),
+            )
 
-        with span.start_child(op="http.client", description="Fetch all IPSWs"):
+            if not qualifying_firmwares:
+                continue
+
+            if version == "latest":
+                actual_version = qualifying_firmwares[-1]["version"]
+            else:
+                actual_version = version
+            firmwares = [x for x in qualifying_firmwares if x["version"] == actual_version]
+
+            for firmware in firmwares:
+                normal_version = regular_version_from_ota_version(firmware["version"])
+                key = normal_version, firmware["buildid"]
+                versions.setdefault(key, {})[firmware["url"]] = firmware
+
+        with span.start_child(op="http.client", description="Fetch all IPSWs for diffing"):
             res = requests.get(f"https://api.ipsw.me/v4/device/{device.identifier}?type=ipsw")
             res.raise_for_status()
 
@@ -288,9 +445,29 @@ def get_otas(os_name: str):
                 normal_version = regular_version_from_ota_version(firmware["version"])
                 versions.pop((firmware["version"], firmware["buildid"]), None)
 
-    import pprint
+    rv = []
 
-    pprint.pprint(versions)
+    for version in versions.values():
+        for info in version.values():
+            ota = OTA(
+                os_name=os_name,
+                device_identifier=info["identifier"],
+                build_number=info["buildid"],
+                os_version=info["version"],
+                url=urlparse(info["url"]),
+            )
+
+            with span.start_child(
+                op="task", description="Check if OTA version has symbols already"
+            ) as symbols_span:
+                if has_symbols_in_cloud_storage(ota.os_name, ota.bundle_id):
+                    symbols_span.set_data("has_symbols_in_cloud_storage", True)
+                    logging.info(f"We already have symbols for {ota.bundle_id}")
+                    continue
+
+            rv.append(ota)
+
+    return rv
 
 
 def regular_version_from_ota_version(ota_version: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 sentry-sdk
+click


### PR DESCRIPTION
This implements OTA handling. It seems to work as verified by running it with `--os_name=tvos --os_version=13.4.8`. That said, I noticed that if you run this on some older OTAs it fails some old OTAs do not contain `payloadv2`.

Fixes #3