### PR TITLE
fix(ipsw): Fix dyld path in iOS 16.0 and up

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+click
+packaging
 requests
 sentry-sdk
-click


### PR DESCRIPTION
New iOS dyld caches are in a different images. This will select the new image to attach and carry on. Fixes https://github.com/getsentry/apple-system-symbols-upload/issues/6.