### PR TITLE
Add Sentry Cron Monitoring

### DIFF
--- a/.github/actions/import-system-symbols-from-ipsw/action.yml
+++ b/.github/actions/import-system-symbols-from-ipsw/action.yml
@@ -20,8 +20,8 @@ runs:
     - name: Import symbols from IPSW
       shell: bash
       if: ${{ inputs.fetch_ipsw }}
-      run: sentry-cli monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
+      run: sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
     - name: Import symbols from OTA
       shell: bash
       if: ${{ inputs.fetch_ota }}
-      run: sentry-cli monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota
+      run: sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota

--- a/.github/actions/import-system-symbols-from-ipsw/action.yml
+++ b/.github/actions/import-system-symbols-from-ipsw/action.yml
@@ -20,8 +20,8 @@ runs:
     - name: Import symbols from IPSW
       shell: bash
       if: ${{ inputs.fetch_ipsw }}
-      run: python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
+      run: sentry-cli monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
     - name: Import symbols from OTA
       shell: bash
       if: ${{ inputs.fetch_ota }}
-      run: python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota
+      run: sentry-cli monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota

--- a/.github/actions/import-system-symbols-from-ipsw/action.yml
+++ b/.github/actions/import-system-symbols-from-ipsw/action.yml
@@ -20,8 +20,8 @@ runs:
     - name: Import symbols from IPSW
       shell: bash
       if: ${{ inputs.fetch_ipsw }}
-      run: sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
+      run: sentry-cli --auth-token ${{ inputs.SENTRY_AUTH_TOKEN }} monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
     - name: Import symbols from OTA
       shell: bash
       if: ${{ inputs.fetch_ota }}
-      run: sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota
+      run: sentry-cli --auth-token ${{ inputs.SENTRY_AUTH_TOKEN }} monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota

--- a/.github/actions/import-system-symbols-from-simulators/action.yml
+++ b/.github/actions/import-system-symbols-from-simulators/action.yml
@@ -11,4 +11,4 @@ runs:
         gcp_service_key: ${{ inputs.gcp_service_key }}
     - name: Import symbols
       shell: bash
-      run: python3 import_system_symbols_from_simulators.py
+      run: sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} monitors run 430ded42-54cb-427b-8fc7-433ac9ca8da5 -- python3 import_system_symbols_from_simulators.py

--- a/.github/actions/import-system-symbols-from-simulators/action.yml
+++ b/.github/actions/import-system-symbols-from-simulators/action.yml
@@ -11,4 +11,4 @@ runs:
         gcp_service_key: ${{ inputs.gcp_service_key }}
     - name: Import symbols
       shell: bash
-      run: sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} monitors run 430ded42-54cb-427b-8fc7-433ac9ca8da5 -- python3 import_system_symbols_from_simulators.py
+      run: sentry-cli --auth-token ${{ inputs.SENTRY_AUTH_TOKEN }} monitors run 430ded42-54cb-427b-8fc7-433ac9ca8da5 -- python3 import_system_symbols_from_simulators.py

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -42,3 +42,5 @@ runs:
     - name: Select Xcode version
       shell: bash
       run: sudo xcode-select -s /Applications/Xcode_13.3.app/Contents/Developer
+    - name: Install sentry-cli
+      run: curl -sL https://sentry.io/get-cli/ | sh

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -43,4 +43,5 @@ runs:
       shell: bash
       run: sudo xcode-select -s /Applications/Xcode_13.3.app/Contents/Developer
     - name: Install sentry-cli
+      shell: bash
       run: curl -sL https://sentry.io/get-cli/ | sh

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -22,6 +22,7 @@ jobs:
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
+        sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
         os_name: tvos
         os_version: latest
         fetch_ota: false
@@ -33,6 +34,7 @@ jobs:
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
+        sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
         os_name: ios
         os_version: latest
         fetch_ota: false
@@ -44,6 +46,7 @@ jobs:
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
+        sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
         os_name: macos
         os_version: latest
         fetch_ota: false
@@ -55,6 +58,7 @@ jobs:
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
+        sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
         os_name: watchos
         os_version: latest
         fetch_ota: false

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron:  '0 */4 * * *' # Check for new IPSWs every 4 hours
 
-  ## Remove before merging
-  push:
-    branches:
-      - chore/cron-monitoring
-
 concurrency:
   group: import-system-symbols-from-ipsw-on-schedule
   cancel-in-progress: true

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron:  '0 */4 * * *' # Check for new IPSWs every 4 hours
 
+  push:
+    branches:
+      - chore/cron-monitoring
+
 concurrency:
   group: import-system-symbols-from-ipsw-on-schedule
   cancel-in-progress: true

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron:  '0 */4 * * *' # Check for new IPSWs every 4 hours
 
+  ## Remove before merging
   push:
     branches:
       - chore/cron-monitoring

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron:  '0 4 * * *' # Check for new IPSWs every 4 hours
 
+  ## Remove before merging
+  push:
+    branches:
+      - chore/cron-monitoring
+
 concurrency:
   group: import-system-symbols-from-simulators-on-schedule
   cancel-in-progress: true

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -22,3 +22,4 @@ jobs:
       uses: ./.github/actions/import-system-symbols-from-simulators
       with:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
+        sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron:  '0 4 * * *' # Check for new IPSWs every 4 hours
 
-  ## Remove before merging
-  push:
-    branches:
-      - chore/cron-monitoring
-
 concurrency:
   group: import-system-symbols-from-simulators-on-schedule
   cancel-in-progress: true


### PR DESCRIPTION
Added two cron monitors to have an overview of how often these jobs run successfully.
* https://sentry.io/organizations/sentry/crons/09666664-597e-490c-ae2e-e1c22795fccd/
* https://sentry.io/organizations/sentry/crons/430ded42-54cb-427b-8fc7-433ac9ca8da5/

