### PR TITLE
Fix Sentry Cron monitoring

### DIFF
--- a/.github/actions/import-system-symbols-from-ipsw/action.yml
+++ b/.github/actions/import-system-symbols-from-ipsw/action.yml
@@ -18,10 +18,14 @@ runs:
       with:
         gcp_service_key: ${{ inputs.gcp_service_key }}
     - name: Import symbols from IPSW
+      env:
+          SENTRY_DSN: ${{ inputs.SENTRY_DSN }}
       shell: bash
       if: ${{ inputs.fetch_ipsw }}
-      run: sentry-cli --auth-token ${{ inputs.SENTRY_AUTH_TOKEN }} monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
+      run: sentry-cli monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
     - name: Import symbols from OTA
+      env:
+          SENTRY_DSN: ${{ inputs.SENTRY_DSN }}
       shell: bash
       if: ${{ inputs.fetch_ota }}
-      run: sentry-cli --auth-token ${{ inputs.SENTRY_AUTH_TOKEN }} monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota
+      run: sentry-cli monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota

--- a/.github/actions/import-system-symbols-from-ipsw/action.yml
+++ b/.github/actions/import-system-symbols-from-ipsw/action.yml
@@ -10,6 +10,8 @@ inputs:
     default: true
   fetch_ota:
     default: false
+  sentry_dsn:
+    required: true
 
 runs:
   using: composite
@@ -19,13 +21,14 @@ runs:
         gcp_service_key: ${{ inputs.gcp_service_key }}
     - name: Import symbols from IPSW
       env:
-          SENTRY_DSN: ${{ inputs.SENTRY_DSN }}
+          SENTRY_DSN: ${{ inputs.sentry_dsn }}
       shell: bash
       if: ${{ inputs.fetch_ipsw }}
       run: sentry-cli monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
+
     - name: Import symbols from OTA
       env:
-          SENTRY_DSN: ${{ inputs.SENTRY_DSN }}
+          SENTRY_DSN: ${{ inputs.sentry_dsn }}
       shell: bash
       if: ${{ inputs.fetch_ota }}
       run: sentry-cli monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota

--- a/.github/actions/import-system-symbols-from-simulators/action.yml
+++ b/.github/actions/import-system-symbols-from-simulators/action.yml
@@ -2,6 +2,8 @@ name: import-system-symbols-from-simulators
 inputs:
   gcp_service_key:
     required: true
+  sentry_dsn:
+    required: true
 
 runs:
   using: composite
@@ -11,6 +13,6 @@ runs:
         gcp_service_key: ${{ inputs.gcp_service_key }}
     - name: Import symbols
       env:
-          SENTRY_DSN: ${{ inputs.SENTRY_DSN }}
+          SENTRY_DSN: ${{ inputs.sentry_dsn }}
       shell: bash
       run: sentry-cli monitors run 430ded42-54cb-427b-8fc7-433ac9ca8da5 -- python3 import_system_symbols_from_simulators.py

--- a/.github/actions/import-system-symbols-from-simulators/action.yml
+++ b/.github/actions/import-system-symbols-from-simulators/action.yml
@@ -10,5 +10,7 @@ runs:
       with:
         gcp_service_key: ${{ inputs.gcp_service_key }}
     - name: Import symbols
+      env:
+          SENTRY_DSN: ${{ inputs.SENTRY_DSN }}
       shell: bash
-      run: sentry-cli --auth-token ${{ inputs.SENTRY_AUTH_TOKEN }} monitors run 430ded42-54cb-427b-8fc7-433ac9ca8da5 -- python3 import_system_symbols_from_simulators.py
+      run: sentry-cli monitors run 430ded42-54cb-427b-8fc7-433ac9ca8da5 -- python3 import_system_symbols_from_simulators.py

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -44,8 +44,5 @@ runs:
       run: sudo xcode-select -s /Applications/Xcode_13.3.app/Contents/Developer
     - name: Install sentry-cli
       shell: bash
-      # Pin to 2.15.2 as authentication with a Sentry AUTH token stopped working in 2.16.0,
-      # and the new recommended authentication with DSN is not working, see
-      # https://github.com/getsentry/sentry-cli/issues/1549 and
-      # https://github.com/getsentry/apple-system-symbols-upload/pull/20.
-      run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.15.2 sh
+      # Pin cli version so builds are reproducible
+      run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.16.1 sh

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron:  '0 */4 * * *' # Check for new IPSWs every 4 hours
 
+  ## Remove before merging 
+  push:
+    branches:
+      - chore/cron-monitoring
+
 concurrency:
   group: import-system-symbols-from-ipsw-on-schedule
   cancel-in-progress: true

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron:  '0 */4 * * *' # Check for new IPSWs every 4 hours
 
-  ## Remove before merging 
-  push:
-    branches:
-      - chore/cron-monitoring
-
 concurrency:
   group: import-system-symbols-from-ipsw-on-schedule
   cancel-in-progress: true

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron:  '0 */4 * * *' # Check for new IPSWs every 4 hours
 
+  ## Remove before merging 
   push:
     branches:
       - chore/cron-monitoring

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron:  '0 */4 * * *' # Check for new IPSWs every 4 hours
 
+  push:
+    branches:
+      - chore/cron-monitoring
+
 concurrency:
   group: import-system-symbols-from-ipsw-on-schedule
   cancel-in-progress: true
@@ -17,7 +21,7 @@ jobs:
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
-        sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        sentry_dsn: ${{ secrets.SENTRY_DSN }}
         os_name: tvos
         os_version: latest
         fetch_ota: false
@@ -29,7 +33,7 @@ jobs:
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
-        sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        sentry_dsn: ${{ secrets.SENTRY_DSN }}
         os_name: ios
         os_version: latest
         fetch_ota: false
@@ -41,7 +45,7 @@ jobs:
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
-        sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        sentry_dsn: ${{ secrets.SENTRY_DSN }}
         os_name: macos
         os_version: latest
         fetch_ota: false
@@ -53,7 +57,7 @@ jobs:
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
-        sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        sentry_dsn: ${{ secrets.SENTRY_DSN }}
         os_name: watchos
         os_version: latest
         fetch_ota: false

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron:  '0 4 * * *' # Check for new IPSWs every 4 hours
 
-  ## Remove before merging 
-  push:
-    branches:
-      - chore/cron-monitoring
-
 concurrency:
   group: import-system-symbols-from-simulators-on-schedule
   cancel-in-progress: true

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron:  '0 4 * * *' # Check for new IPSWs every 4 hours
 
+  ## Remove before merging
+  push:
+    branches:
+      - chore/cron-monitoring
+
 concurrency:
   group: import-system-symbols-from-simulators-on-schedule
   cancel-in-progress: true

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -17,4 +17,4 @@ jobs:
       uses: ./.github/actions/import-system-symbols-from-simulators
       with:
         gcp_service_key: ${{ secrets.GCP_SERVICE_KEY }}
-        sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        sentry_dsn: ${{ secrets.SENTRY_dsn }}

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron:  '0 4 * * *' # Check for new IPSWs every 4 hours
 
+  ## Remove before merging 
+  push:
+    branches:
+      - chore/cron-monitoring
+
 concurrency:
   group: import-system-symbols-from-simulators-on-schedule
   cancel-in-progress: true

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron:  '0 4 * * *' # Check for new IPSWs every 4 hours
 
-  ## Remove before merging
+  ## Remove before merging 
   push:
     branches:
       - chore/cron-monitoring


### PR DESCRIPTION
Replace deprecated auth token with dsn, as pointed out in the docs see https://docs.sentry.io/product/crons/getting-started/cli/.

Blocked by https://github.com/getsentry/sentry-cli/issues/1549. Solved the underlying problem temporarily my pinning sentry-cli to `2.15.2` https://github.com/getsentry/apple-system-symbols-upload/pull/21.