### PR TITLE
Fix passing os to transaction name

### DIFF
--- a/import_system_symbols_from_ipsw.py
+++ b/import_system_symbols_from_ipsw.py
@@ -119,7 +119,7 @@ def main(os_name, os_version, type, no_upload):
 
 def main_download_otas(os_name: str, os_version: str, upload: bool = True):
     with sentry_sdk.start_transaction(
-        op="task", name="import symbols from OTA archive for {os_name}"
+        op="task", name=f"import symbols from OTA archive for {os_name}"
     ) as transaction:
         with sentry_sdk.start_transaction(op="task", name="Checking OTAs") as transaction:
             with transaction.start_child(op="task", description="Check for new versions") as span:
@@ -168,7 +168,7 @@ def main_download_otas(os_name: str, os_version: str, upload: bool = True):
 
 def main_download_ipsws(os_name: str, os_version: str, upload: bool = True):
     with sentry_sdk.start_transaction(
-        op="task", name="import symbols from IPSW archive for {os_name}"
+        op="task", name=f"import symbols from IPSW archive for {os_name}"
     ) as transaction:
         with transaction.start_child(op="task", description="Check for new versions") as span:
             ipsws = get_missing_ipsws(os_name, os_version)


### PR DESCRIPTION
We forgot to add the `f` so Python formats the string.