### PR TITLE
Run symbols import on macos-11 and macos-13

### DIFF
--- a/.github/actions/import-system-symbols-from-simulators/action.yml
+++ b/.github/actions/import-system-symbols-from-simulators/action.yml
@@ -17,4 +17,4 @@ runs:
       env:
           SENTRY_DSN: ${{ inputs.sentry_dsn }}
       shell: bash
-      run: python3 import_system_symbols_from_simulators.py
+      run: sentry-cli monitors run 430ded42-54cb-427b-8fc7-433ac9ca8da5 -- python3 import_system_symbols_from_simulators.py

--- a/.github/actions/import-system-symbols-from-simulators/action.yml
+++ b/.github/actions/import-system-symbols-from-simulators/action.yml
@@ -17,4 +17,4 @@ runs:
       env:
           SENTRY_DSN: ${{ inputs.sentry_dsn }}
       shell: bash
-      run: sentry-cli monitors run 430ded42-54cb-427b-8fc7-433ac9ca8da5 -- python3 import_system_symbols_from_simulators.py
+      run: python3 import_system_symbols_from_simulators.py

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -39,9 +39,6 @@ runs:
     - name: "Install Python dependencies"
       shell: bash
       run: python3 -m pip install --user -r requirements.txt
-    - name: Select Xcode version
-      shell: bash
-      run: sudo xcode-select -s /Applications/Xcode_13.3.app/Contents/Developer
     - name: Install sentry-cli
       shell: bash
       # Pin cli version so builds are reproducible

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -4,13 +4,21 @@ on:
   schedule:
     - cron:  '0 4 * * *' # Check for new IPSWs every 4 hours
 
+  push:
+    branches:
+        - feat/import-symbols-macos-versions
+
 concurrency:
   group: import-system-symbols-from-simulators-on-schedule
   cancel-in-progress: true
 
 jobs:
   import-system-symbols-from-simulators:
-    runs-on: 'macos-12'
+    runs-on: ${{matrix.runs-on}}
+    strategy:
+      matrix:
+        runs-on: [macos-11, macos-12, macos-13]
+
     steps:
     - uses: actions/checkout@v2
     - name: Import system symbols from simulators

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -16,6 +16,7 @@ jobs:
   import-system-symbols-from-simulators:
     runs-on: ${{matrix.runs-on}}
     strategy:
+      fail-fast: false
       matrix:
         runs-on: [macos-11, macos-12, macos-13]
 

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     - cron:  '0 4 * * *' # Check for new IPSWs every 4 hours
 
-  push:
-    branches:
-        - feat/import-symbols-macos-versions
-
 concurrency:
   group: import-system-symbols-from-simulators-on-schedule
   cancel-in-progress: true

--- a/import_system_symbols_from_simulators.py
+++ b/import_system_symbols_from_simulators.py
@@ -40,9 +40,6 @@ def main():
     ) as transaction:
         with tempfile.TemporaryDirectory(prefix="_sentry_dyld_shared_cache_") as output_dir:
             for runtime in find_simulator_runtimes(caches_path):
-                logging.info(
-                    f"Checking symbols for macOS {runtime.macos_version}, {runtime.os_name} {runtime.os_version} {runtime.arch}"
-                )
 
                 with transaction.start_child(
                     op="task", description="Process runtime"

--- a/import_system_symbols_from_simulators.py
+++ b/import_system_symbols_from_simulators.py
@@ -40,6 +40,10 @@ def main():
     ) as transaction:
         with tempfile.TemporaryDirectory(prefix="_sentry_dyld_shared_cache_") as output_dir:
             for runtime in find_simulator_runtimes(caches_path):
+                logging.info(
+                    f"Checking symbols for macOS {runtime.macos_version}, {runtime.os_name} {runtime.os_version} {runtime.arch}"
+                )
+
                 with transaction.start_child(
                     op="task", description="Process runtime"
                 ) as runtime_span:


### PR DESCRIPTION
Run the import on different GH action runners to import more different types
simulator runtimes. Each GH image has a different set of preinstalled simulators, see
 * [macos-11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md)
 * [macos-12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md)
 * [macos-13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)