### PR TITLE
ci: Update sentry-cli version to 2.21.2

### DIFF
--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -39,9 +39,6 @@ runs:
     - name: "Install Python dependencies"
       shell: bash
       run: python3 -m pip install --user -r requirements.txt
-    - name: Select Xcode version
-      shell: bash
-      run: sudo xcode-select -s /Applications/Xcode_13.3.app/Contents/Developer
     - name: Install sentry-cli
       shell: bash
       # Pin cli version so builds are reproducible

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -42,4 +42,4 @@ runs:
     - name: Install sentry-cli
       shell: bash
       # Pin cli version so builds are reproducible
-      run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.16.1 sh
+      run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.21.2 sh

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -10,7 +10,12 @@ concurrency:
 
 jobs:
   import-system-symbols-from-simulators:
-    runs-on: 'macos-12'
+    runs-on: ${{matrix.runs-on}}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [macos-11, macos-12, macos-13]
+
     steps:
     - uses: actions/checkout@v2
     - name: Import system symbols from simulators

--- a/import_system_symbols_from_simulators.py
+++ b/import_system_symbols_from_simulators.py
@@ -40,6 +40,7 @@ def main():
     ) as transaction:
         with tempfile.TemporaryDirectory(prefix="_sentry_dyld_shared_cache_") as output_dir:
             for runtime in find_simulator_runtimes(caches_path):
+
                 with transaction.start_child(
                     op="task", description="Process runtime"
                 ) as runtime_span:


### PR DESCRIPTION
sentry-cli 2.16.1 uses the deprecated crons API, which will be deprecated by January 1st, 2024. Updating to the latest version fixes this problem.

This PR is based on https://github.com/getsentry/apple-system-symbols-upload/pull/28.