### PR TITLE
ci: Add cron monitors per platform for IPSW

### DIFF
--- a/.github/actions/import-system-symbols-from-ipsw/action.yml
+++ b/.github/actions/import-system-symbols-from-ipsw/action.yml
@@ -26,11 +26,11 @@ runs:
           SENTRY_DSN: ${{ inputs.sentry_dsn }}
       shell: bash
       if: ${{ inputs.fetch_ipsw }}
-      run: sentry-cli monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
+      run: sentry-cli monitors run ${{ inputs.cron_monitor_slug }} -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ipsw
 
     - name: Import symbols from OTA
       env:
           SENTRY_DSN: ${{ inputs.sentry_dsn }}
       shell: bash
       if: ${{ inputs.fetch_ota }}
-      run: sentry-cli monitors run 09666664-597e-490c-ae2e-e1c22795fccd -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota
+      run: sentry-cli monitors run ${{ inputs.cron_monitor_slug }} -- python3 import_system_symbols_from_ipsw.py --os-name ${{ inputs.os_name }} --os-version ${{ inputs.os_version }} --type=ota

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -39,9 +39,6 @@ runs:
     - name: "Install Python dependencies"
       shell: bash
       run: python3 -m pip install --user -r requirements.txt
-    - name: Select Xcode version
-      shell: bash
-      run: sudo xcode-select -s /Applications/Xcode_13.3.app/Contents/Developer
     - name: Install sentry-cli
       shell: bash
       # Pin cli version so builds are reproducible

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -42,4 +42,4 @@ runs:
     - name: Install sentry-cli
       shell: bash
       # Pin cli version so builds are reproducible
-      run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.16.1 sh
+      run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.21.2 sh

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -27,6 +27,8 @@ jobs:
         os_name: tvos
         os_version: latest
         fetch_ota: false
+        cron_monitor_slug: import-symbols-from-ipsw-tvos
+
   import-ios-system-symbols-from-ipsw:
     runs-on: 'macos-12'
     steps:
@@ -39,6 +41,8 @@ jobs:
         os_name: ios
         os_version: latest
         fetch_ota: false
+        cron_monitor_slug: import-symbols-from-ipsw-ios
+
   import-macos-system-symbols-from-ipsw:
     runs-on: 'macos-12'
     steps:
@@ -51,6 +55,8 @@ jobs:
         os_name: macos
         os_version: latest
         fetch_ota: false
+        cron_monitor_slug: import-symbols-from-ipsw-macos
+
   import-watchos-system-symbols-from-ipsw:
     runs-on: 'macos-12'
     steps:
@@ -63,3 +69,4 @@ jobs:
         os_name: watchos
         os_version: latest
         fetch_ota: false
+        cron_monitor_slug: import-symbols-from-ipsw-for-watchos

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -10,7 +10,12 @@ concurrency:
 
 jobs:
   import-system-symbols-from-simulators:
-    runs-on: 'macos-12'
+    runs-on: ${{matrix.runs-on}}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [macos-11, macos-12, macos-13]
+
     steps:
     - uses: actions/checkout@v2
     - name: Import system symbols from simulators

--- a/import_system_symbols_from_simulators.py
+++ b/import_system_symbols_from_simulators.py
@@ -40,6 +40,7 @@ def main():
     ) as transaction:
         with tempfile.TemporaryDirectory(prefix="_sentry_dyld_shared_cache_") as output_dir:
             for runtime in find_simulator_runtimes(caches_path):
+
                 with transaction.start_child(
                     op="task", description="Process runtime"
                 ) as runtime_span:


### PR DESCRIPTION
Add cron monitors per platform for IPSW so we can track them separately in Sentry.