### PR TITLE
Fix importer actions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click
 packaging
 requests
-sentry-sdk
+sentry-sdk<2.0.0


### PR DESCRIPTION
...by pinning the sentry python SDK to 1.x.