### PR TITLE
feat: support aea-encrypted images

### DIFF
--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -43,3 +43,6 @@ runs:
       shell: bash
       # Pin cli version so builds are reproducible
       run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.21.2 sh
+    - name: Install ipsw
+      shell: bash
+      run: brew install ipsw


### PR DESCRIPTION
Mounting failed in recent workflow runs:

https://github.com/getsentry/apple-system-symbols-upload/actions/runs/10902614747/job/30254908149#step:3:328

The reason is that the images to be mounted are aea-encrypted DMGs. This PR adds support for these.