### PR TITLE
fix: symlink error for cask python 3.11 on macos-13

### DIFF
--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: "Install Google Cloud SDK"
       shell: bash
       run: |
-        brew cleanup --prune-prefix python@3.11
+        brew cleanup --prune-prefix
         brew install --cask google-cloud-sdk
         echo "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin" >> $GITHUB_PATH
     - name: "Set up GCP access"

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -12,6 +12,7 @@ runs:
     - name: "Install Google Cloud SDK"
       shell: bash
       run: |
+        brew cleanup --prune-prefix python@3.11
         brew install --cask google-cloud-sdk
         echo "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin" >> $GITHUB_PATH
     - name: "Set up GCP access"

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -12,7 +12,8 @@ runs:
     - name: "Install Google Cloud SDK"
       shell: bash
       run: |
-        brew cleanup --prune-prefix
+        # workaround GHA python@3.11 conflict see https://github.com/Homebrew/homebrew-core/issues/173191#issuecomment-2138608778
+        brew unlink python@3.11 && brew link --overwrite python@3.11
         brew install --cask google-cloud-sdk
         echo "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin" >> $GITHUB_PATH
     - name: "Set up GCP access"

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -9,11 +9,16 @@ runs:
     - uses: actions/setup-python@v3
       with:
         python-version: '3.x'
+    - name: "Workaround GHA python@3.11 conflict"
+      shell: bash
+      run: |
+        # macos-13 breaks when brew install --cask google-cloud-sdk tries to link python@3.11 due to
+        # conflicting preinstall, see https://github.com/Homebrew/homebrew-core/issues/173191#issuecomment-2138608778
+        # we should be able to remove this when we remove macos-13 from the matrix
+        brew install --overwrite python@3.11
     - name: "Install Google Cloud SDK"
       shell: bash
       run: |
-        # workaround GHA python@3.11 conflict see https://github.com/Homebrew/homebrew-core/issues/173191#issuecomment-2138608778
-        brew install --overwrite python@3.11
         brew install --cask google-cloud-sdk
         echo "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin" >> $GITHUB_PATH
     - name: "Set up GCP access"

--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
       run: |
         # workaround GHA python@3.11 conflict see https://github.com/Homebrew/homebrew-core/issues/173191#issuecomment-2138608778
-        brew unlink python@3.11 && brew link --overwrite python@3.11
+        brew install --overwrite python@3.11
         brew install --cask google-cloud-sdk
         echo "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin" >> $GITHUB_PATH
     - name: "Set up GCP access"


### PR DESCRIPTION
macos-13 simulator job breaks when `brew install --cask google-cloud-sdk` tries to link python@3.11 due to conflicting GHA runner image preinstall, see https://github.com/Homebrew/homebrew-core/issues/173191#issuecomment-2138608778
we should be able to remove this when we remove macos-13 from the matrix