### PR TITLE
fix: ignore external dsc atlas when iterating dsc files

### DIFF
--- a/import_system_symbols_from_simulators.py
+++ b/import_system_symbols_from_simulators.py
@@ -27,6 +27,14 @@ class SimulatorRuntime:
 
 _simulator_runtime_prefix = "com.apple.CoreSimulator.SimRuntime."
 _dyld_shared_cache_prefix = "dyld_sim_shared_cache_"
+_ignored_dyld_file_suffixes = (".map", ".atlas")
+
+
+def _is_ignored_dsc_file(filename: str) -> bool:
+    return (
+        not filename.startswith(_dyld_shared_cache_prefix)
+        or os.path.splitext(filename)[1] in _ignored_dyld_file_suffixes
+    )
 
 
 def main():
@@ -40,16 +48,14 @@ def main():
     ) as transaction:
         with tempfile.TemporaryDirectory(prefix="_sentry_dyld_shared_cache_") as output_dir:
             for runtime in find_simulator_runtimes(caches_path):
-
                 with transaction.start_child(
                     op="task", description="Process runtime"
                 ) as runtime_span:
                     runtime_span.set_data("runtime", runtime)
                     for filename in os.listdir(runtime.path):
-                        if not filename.startswith(_dyld_shared_cache_prefix):
+                        if _is_ignored_dsc_file(filename):
                             continue
-                        if os.path.splitext(filename)[1] == ".map":
-                            continue
+
                         with runtime_span.start_child(
                             op="task", description="Process file"
                         ) as file_span:
@@ -108,10 +114,9 @@ def find_simulator_runtimes(caches_path: str) -> List[SimulatorRuntime]:
 def extract_system_symbols(runtime: SimulatorRuntime, output_dir: str) -> None:
     span = sentry_sdk.Hub.current.scope.span
     for filename in os.listdir(runtime.path):
-        if not filename.startswith(_dyld_shared_cache_prefix):
+        if _is_ignored_dsc_file(filename):
             continue
-        if os.path.splitext(filename)[1] == ".map":
-            continue
+
         with span.start_child(
             op="task", description="Extract symbols from runtime file"
         ) as file_span:


### PR DESCRIPTION
This was the cause of a recent extraction failure when an `xrOS` simulator image seemingly had its "atlas" packaged as an external file ([workflow log](https://github.com/getsentry/apple-system-symbols-upload/actions/runs/14372072865/job/40296882604)).