### PR TITLE
fix: manage python + gcloud solely via actions

### DIFF
--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -3,29 +3,21 @@ name: import-system-symbols-from-ipsw
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - name: "Workaround GHA python@3.11 conflict"
-      shell: bash
-      run: |
-        # macos-13 breaks when brew install --cask google-cloud-sdk tries to link python@3.11 due to
-        # conflicting preinstall, see https://github.com/Homebrew/homebrew-core/issues/173191#issuecomment-2138608778
-        # we should be able to remove this when we remove macos-13 from the matrix
-        brew install --overwrite python@3.11
-    - name: "Install Google Cloud SDK"
-      shell: bash
-      run: |
-        brew install --cask google-cloud-sdk
-        echo "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin" >> $GITHUB_PATH
     - name: "Set up GCP access"
       uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935
       with:
         workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
         service_account: gha-apple-system-symbols@sac-prod-sa.iam.gserviceaccount.com
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+      with:
+        version: '>= 363.0.0'
     - name: "Install dependencies"
       shell: bash
-      run: brew install p7zip lzip keith/formulae/dyld-shared-cache-extractor
+      run: brew install lzip keith/formulae/dyld-shared-cache-extractor
     - name: "Compile ios-utils"
       shell: bash
       run: cd ios-utils && make

--- a/import_system_symbols_from_ipsw.py
+++ b/import_system_symbols_from_ipsw.py
@@ -682,6 +682,7 @@ def has_symbols_in_cloud_storage(prefix: str, bundle_id: str) -> bool:
         return True
     elif "not found" in result.stdout:
         return False
+    logging.error(f"`has_symbols_in_cloud_storage()` failed with an unexpected error:\n{result.stdout}")
     # Fallback to raising an exception for other errors.
     result.check_returncode()
     return False


### PR DESCRIPTION
As mentioned in #35, when a [similar issue appears again](https://github.com/getsentry/apple-system-symbols-upload/actions/runs/15674369553/job/44171693488#step:3:445), we switch to either side (managed solely via homebrew or GitHub Actions). I currently see no reason why managing Python and GCloud via actions wouldn't sufficiently serve this use case (and lead to a much lighter maintenance effort, as we don't have to sync runner images with `brew` packages whenever there is an update).

Also adds error logging to the unknown error path when querying bundles on Google Cloud Storage (GCS), which otherwise only shows that the executable returned 1, skipping helpful information from the `gcloud` output.

Remove `p7zip` from the `brew` dependencies, since it comes preinstalled with the images and only generates "warning" noise in the logs.