### PR TITLE
fix: provide workaround for pinned CMake on macOS GHA runner

### DIFF
--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -15,6 +15,13 @@ runs:
       uses: 'google-github-actions/setup-gcloud@v2'
       with:
         version: '>= 363.0.0'
+    - name: Workaround for pinned CMake
+      shell: bash
+      run: |
+        set -eou pipefail
+        brew uninstall cmake
+        brew untap local/pinned
+        brew install cmake
     - name: "Install dependencies"
       shell: bash
       run: brew install lzip keith/formulae/dyld-shared-cache-extractor


### PR DESCRIPTION
Until [this](https://github.com/actions/runner-images/issues/12934) is rolled out, we need the workaround to keep the workflows running.