### PR TITLE
fix: ignore failed `brew untap`

### DIFF
--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -20,7 +20,7 @@ runs:
       run: |
         set -eou pipefail
         brew uninstall cmake
-        brew untap local/pinned
+        brew untap local/pinned || true
         brew install cmake
     - name: "Install dependencies"
       shell: bash


### PR DESCRIPTION
As expected, the first GHA runner images without a pinned CMake rolled out. These no longer have a `local/pinned` brew tap, and consequently, `brew untap` fails.

We still cannot remove the entire procedure because the rollout currently only happened for `macos-13` and `macos-15` runner images. Therefore, a temporary fix until all runner images have unpinned the CMake homebrew package config is the way to go. 

A PR that unpins CMake for `macos-14` is already out there: https://github.com/actions/runner-images/pull/13016.