### PR TITLE
fix: remove the CMake workaround

### DIFF
--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -15,13 +15,6 @@ runs:
       uses: 'google-github-actions/setup-gcloud@v2'
       with:
         version: '>= 363.0.0'
-    - name: Workaround for pinned CMake
-      shell: bash
-      run: |
-        set -eou pipefail
-        brew uninstall cmake
-        brew untap local/pinned || true
-        brew install cmake
     - name: "Install dependencies"
       shell: bash
       run: brew install lzip keith/formulae/dyld-shared-cache-extractor


### PR DESCRIPTION
Since all jobs have been experiencing a missing tap issue for at least a week now (which means the new CMake version was rolled out on all runner images consistently), we can revert the workaround changes to eliminate error noise:

### runners used for regular IPSWs:
<img width="673" height="329" alt="image" src="https://github.com/user-attachments/assets/16d1e6e0-55b9-4fc4-9dec-65ff89a6b3a3" />

### runners used for simulator images:
<img width="729" height="252" alt="image" src="https://github.com/user-attachments/assets/aa19bf4a-bd16-4320-99ef-ae1daafd5756" />
