### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/setup-import-system-symbols/action.yml
+++ b/.github/actions/setup-import-system-symbols/action.yml
@@ -3,7 +3,7 @@ name: import-system-symbols-from-ipsw
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.x'
     - name: "Set up GCP access"
@@ -12,7 +12,7 @@ runs:
         workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
         service_account: gha-apple-system-symbols@sac-prod-sa.iam.gserviceaccount.com
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v2'
+      uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
       with:
         version: '>= 363.0.0'
     - name: "Install dependencies"

--- a/.github/workflows/import-system-symbols-from-ipsw-manually.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-manually.yml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Import system symbols for ${{ github.event.inputs.os_name }}
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:

--- a/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-ipsw-on-schedule.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Import system symbols for tvOS
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
@@ -37,7 +37,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Import system symbols for iOS
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
@@ -53,7 +53,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Import system symbols for macOS
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:
@@ -69,7 +69,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Import system symbols for watchOS
       uses: ./.github/actions/import-system-symbols-from-ipsw
       with:

--- a/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
+++ b/.github/workflows/import-system-symbols-from-simulators-on-schedule.yml
@@ -26,7 +26,7 @@ jobs:
         runs-on: [macos-13, macos-14, macos-15]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Import system symbols from simulators
       uses: ./.github/actions/import-system-symbols-from-simulators
       with:


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)